### PR TITLE
Fix NPE

### DIFF
--- a/core/src/main/java/com/zigythebird/playeranimcore/animation/AnimationController.java
+++ b/core/src/main/java/com/zigythebird/playeranimcore/animation/AnimationController.java
@@ -698,7 +698,8 @@ public abstract class AnimationController implements IAnimation {
 	 * tick + tick delta
 	 */
 	public float getAnimationTicks() {
-		return this.tick + this.startAnimFrom + animationData.getPartialTick();
+		if (this.animationData == null) return 0F;
+		return this.tick + this.startAnimFrom + this.animationData.getPartialTick();
 	}
 
 	public boolean hasBeginTick() {


### PR DESCRIPTION
Fixes:
```java
java.lang.NullPointerException: Cannot invoke "com.zigythebird.playeranimcore.animation.AnimationData.getPartialTick()" because "this.animationData" is null
	at TRANSFORMER/player_animation_library@0.2.0+dev+mc1.21.1/com.zigythebird.playeranimcore.animation.AnimationController.getAnimationTicks(AnimationController.java:632) ~[PlayerAnimationLibNeo-0.2.0+dev+mc1.21.1.jar%23194!/:?] {re:classloading}
	at TRANSFORMER/player_animation_library@0.2.0+dev+mc1.21.1/com.zigythebird.playeranimcore.animation.AnimationController.getAnimationTime(AnimationController.java:624) ~[PlayerAnimationLibNeo-0.2.0+dev+mc1.21.1.jar%23194!/:?] {re:classloading}
	other
```