### PR TITLE
Store `pre_effect_expression` as molang

### DIFF
--- a/core/src/main/java/com/zigythebird/playeranimcore/animation/keyframe/event/data/ParticleKeyframeData.java
+++ b/core/src/main/java/com/zigythebird/playeranimcore/animation/keyframe/event/data/ParticleKeyframeData.java
@@ -25,7 +25,9 @@
 package com.zigythebird.playeranimcore.animation.keyframe.event.data;
 
 import com.zigythebird.playeranimcore.animation.keyframe.Keyframe;
+import team.unnamed.mocha.parser.ast.Expression;
 
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -34,9 +36,9 @@ import java.util.Objects;
 public class ParticleKeyframeData extends KeyFrameData {
 	private final String effect;
 	private final String locator;
-	private final String script;
+	private final List<Expression> script;
 
-	public ParticleKeyframeData(float startTick, String effect, String locator, String script) {
+	public ParticleKeyframeData(float startTick, String effect, String locator, List<Expression> script) {
 		super(startTick);
 
 		this.script = script;
@@ -61,7 +63,7 @@ public class ParticleKeyframeData extends KeyFrameData {
 	/**
 	 * Gets the script string given by the {@link Keyframe} instruction from the {@code animation.json}
 	 */
-	public String script() {
+	public List<Expression> script() {
 		return this.script;
 	}
 

--- a/core/src/main/java/com/zigythebird/playeranimcore/loading/KeyFrameLoader.java
+++ b/core/src/main/java/com/zigythebird/playeranimcore/loading/KeyFrameLoader.java
@@ -6,9 +6,12 @@ import com.zigythebird.playeranimcore.animation.Animation;
 import com.zigythebird.playeranimcore.animation.keyframe.event.data.CustomInstructionKeyframeData;
 import com.zigythebird.playeranimcore.animation.keyframe.event.data.ParticleKeyframeData;
 import com.zigythebird.playeranimcore.animation.keyframe.event.data.SoundKeyframeData;
+import com.zigythebird.playeranimcore.molang.MolangLoader;
 import com.zigythebird.playeranimcore.util.JsonUtil;
+import team.unnamed.mocha.parser.ast.Expression;
 
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -45,7 +48,7 @@ public class KeyFrameLoader implements JsonDeserializer<Animation.Keyframes> {
 			JsonObject obj = entry.getValue().getAsJsonObject();
 			String effect = JsonUtil.getAsString(obj, "effect", "");
 			String locator = JsonUtil.getAsString(obj, "locator", "");
-			String script = JsonUtil.getAsString(obj, "pre_effect_script", "");
+			List<Expression> script = MolangLoader.parseJson(false, obj.get("pre_effect_script"), Collections.emptyList());
 
 			particles[index] = new ParticleKeyframeData(Float.parseFloat(entry.getKey()) * 20f, effect, locator, script);
 			index++;

--- a/core/src/main/java/com/zigythebird/playeranimcore/molang/MolangLoader.java
+++ b/core/src/main/java/com/zigythebird/playeranimcore/molang/MolangLoader.java
@@ -39,10 +39,15 @@ public class MolangLoader {
 
     @Contract("_, null, _ -> param3; _, !null, _ -> !null")
     public static List<Expression> parseJson(boolean isForRotation, @Nullable JsonElement element, @NotNull List<Expression> defaultValue) {
-        if (element == null) return defaultValue;
+        return parseJson(isForRotation, element == null ? null : element.getAsString(), defaultValue);
+    }
+
+    @Contract("_, null, _ -> param3; _, !null, _ -> !null")
+    public static List<Expression> parseJson(boolean isForRotation, @Nullable String string, @NotNull List<Expression> defaultValue) {
+        if (string == null) return defaultValue;
 
         List<Expression> expressions;
-        try (MolangParser parser = MolangParser.parser(element.getAsString())) {
+        try (MolangParser parser = MolangParser.parser(string)) {
             List<Expression> expressions1 = parser.parseAll();
             if (expressions1.size() == 1 && isForRotation && IsConstantExpression.test(expressions1.getFirst())) {
                 expressions = new ArrayList<>();
@@ -51,7 +56,7 @@ public class MolangLoader {
                 expressions = expressions1;
             }
         } catch (IOException e) {
-            PlayerAnimLib.LOGGER.error("Failed to compile molang '{}'!", element, e);
+            PlayerAnimLib.LOGGER.error("Failed to compile molang '{}'!", string, e);
             return defaultValue;
         }
         return expressions;


### PR DESCRIPTION
According to the bedrock documentation, `pre_effect_expression` is a molang, so why don't we store it as a real molang?

ParticleTsunami already reads like molang, and we also save bytes when writing it over the network because writing molang is more efficient than strings.