### PR TITLE
Fix model disappearing for one frame during looping animations

### DIFF
--- a/core/src/main/java/com/zigythebird/playeranimcore/animation/AnimationController.java
+++ b/core/src/main/java/com/zigythebird/playeranimcore/animation/AnimationController.java
@@ -482,7 +482,7 @@ public abstract class AnimationController implements IAnimation {
 	 * @param state                 The animation test state
 	 */
 	public void process(AnimationData state) {
-		float adjustedTick = state.getPartialTick() + this.startAnimFrom + tick;
+		float adjustedTick = Math.max(0.0F, state.getPartialTick() + this.startAnimFrom + tick);
 
 		PlayState playState = handleAnimation(state);
 


### PR DESCRIPTION
The Issue:
Under unstable TPS/FPS (common in modpack environments), floating-point precision loss can cause `adjustedTick` to become a tiny negative value when a looping animation restarts. This unexpectedly triggers a division-by-zero error during keyframe interpolation. Consequently, it generates `NaN` values that corrupt the OpenGL rendering matrix, causing the player model to flicker or completely disappear for a frame.

The Fix:
Clamped `adjustedTick `in `AnimationController.process()` using `Math.max(0.0F, ...)` to ensure the animation time never falls below zero. This safely prevents the negative tick bounds check failure and the subsequent `NaN` propagation.