### PR TITLE
Fix model disappearing for one frame during looping animations

### DIFF
--- a/core/src/main/java/com/zigythebird/playeranimcore/animation/AnimationController.java
+++ b/core/src/main/java/com/zigythebird/playeranimcore/animation/AnimationController.java
@@ -478,7 +478,7 @@ public abstract class AnimationController implements IAnimation {
 	 * @param state                 The animation test state
 	 */
 	public void process(AnimationData state) {
-		float adjustedTick = state.getPartialTick() + this.startAnimFrom + tick;
+		float adjustedTick = Math.max(0.0F, state.getPartialTick() + this.startAnimFrom + tick);
 
 		PlayState playState = handleAnimation(state);
 


### PR DESCRIPTION
**The Issue:**
Under unstable TPS/FPS (common in modpack environments), floating-point precision loss can cause `adjustedTick` to become a tiny negative value when a looping animation restarts. This unexpectedly triggers a division-by-zero error during keyframe interpolation. Consequently, it generates `NaN` values that corrupt the OpenGL rendering matrix, causing the player model to flicker or completely disappear for a frame.

**The Fix:**
Clamped `adjustedTick` in `AnimationController.process()` using `Math.max(0.0F, ...)` to ensure the animation time never falls below zero. This safely prevents the negative tick bounds check failure and the subsequent `NaN` propagation.

---
**A humble request regarding 1.21.1:**
My upcoming parkour mod is getting ready for release and is currently built exclusively for 1.21.1. Porting it to the newer versions (like 26.1) is still going to take me a month or two. Since this bug heavily impacts continuous animations, I would be incredibly grateful if this fix could also be released/backported for the `1.21.1` branch! Please and thank you! 